### PR TITLE
Fixes peer dependencies and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hapi-pg-promise",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Wrap requests with a pg connection.",
 	"keywords": [
 		"hapi",
@@ -34,8 +34,8 @@
 		"proxyquire": "^1.x.x"
 	},
 	"peerDependencies": {
-		"hapi": "12.x",
-		"pg-promise": "3.x"
+		"hapi": "^12.x",
+		"pg-promise": "^3.x"
 	},
 	"engines": {
 		"node": ">=4.0.0"


### PR DESCRIPTION
I think version `0.0.4` broke the peer dependencies with npm. So, this fixes https://github.com/dszczyt/hapi-pg-promise/commit/83c081a6ec9bdf0eebce73827775f6e62821073e.
