### PR TITLE
minor: update dependencies to allow Hapi 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hapi-pg-promise",
-	"version": "0.0.6",
+	"version": "1.0.0",
 	"description": "Wrap requests with a pg connection.",
 	"keywords": [
 		"hapi",
@@ -28,13 +28,13 @@
 		"hoek": "4.x"
 	},
 	"devDependencies": {
-		"hapi": "15.x",
+		"hapi": ">=15.0.0",
 		"code": "^4.x.x",
 		"lab": "^11.x.x",
 		"proxyquire": "^1.x.x"
 	},
 	"peerDependencies": {
-		"hapi": "15.x",
+		"hapi": ">=15.0.0",
 		"pg-promise": "5.x"
 	},
 	"engines": {


### PR DESCRIPTION
We allow hapi-pg-promise to go with Hapi 16. No breakage ([Hapi 16 release notes](https://github.com/hapijs/hapi/issues/3398)) and its not very likely to break plugin additions in future either. Will keep an eye on it.

I also took liberty to bump the version for the package. We use it heavily and 0.0.x does not do hapi-pg-promsie justice. Please also publish it on npm 🙏 . 